### PR TITLE
Filter Fixed, Re-structured, and Expanded, Addresses Issue #1

### DIFF
--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -2,7 +2,8 @@ TWITTER_CONSUMER_KEY    = "";
 TWITTER_CONSUMER_SECRET = "";
 TWITTER_ACCESS_TOKEN    = "";
 TWITTER_ACCESS_SECRET   = "";
-TWITTER_SEARCH_PHRASE   = "python -filter:nativeretweets -filter:retweets -filter:replies";
+TWITTER_SEARCH_PHRASE   = "python -filter:nativeretweets -filter:retweets -filter:replies"; 
+//filters out replies, retweets, and old-style retweets(RT)
 
 //variables for array of excluded words and a variable for the length of the array
 //words will be added as I continue to find false positives
@@ -59,11 +60,7 @@ function retweet_Python() {
     
     var props = PropertiesService.getScriptProperties(),
         twit = new Twitter.OAuth(props);
-    
-    //reduced function to check if tweet is relevant enough for bot to retweet
-    //filters based on word list and sensitivity
-    //if any of the if conditions match, it returns false (not relevant) and fetchTweets will not fetch it
-    //otherwise it returns the tweet
+  
       function isTweetRelevant(tweetobj){
         
         //if the tweet text property does not contain the word python in some form, return false

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -85,7 +85,7 @@ function retweet_Python() {
       
       if (tweets.length) {
         
-        props.setProperty("SINCE_TWITTER_ID", tweets[0]);
+        props.setProperty("SINCE_TWITTER_ID", tweets[0].id_str);
         
         for (var i = tweets.length - 1; i >= 0; i--) {
           

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -61,7 +61,7 @@ function retweet_Python() {
         
         for (var i = 0; i < numexcluded; i++){
           if (tweetobj.text.indexOf(excluded[i]) !== -1 || tweetobj.possibly_sensitive){
-            Logger.log(tweetobj.text);
+            
             return false;
           }
         }

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -11,7 +11,7 @@ var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", 
                 "montypython", "MontyPython", "pet", "Pet", "#pet", "Dance", "dance", "Police", "police", "Leather", "leather",
                 "Pants", "pants", "Handbag", "handbag", "forsyth", "Forsyth", "Ball Python" , "Nigeria", "nigeria", "creatur.io", "Slither.io",
                 "BallPython", "ballpython", "#BallPython", "#ballpython", "Python Temple", "#pythontemple", "Luthier", "versace", "Versace", "Python's Realm",
-                "Dangerous", "jaw", "swallow", "Swallow", "Kyle Python", "Python Plan", "Python Skin", "python skin"];
+                "Dangerous", "jaw", "swallow", "Swallow", "Kyle Python", "Python Plan", "Python Skin", "python skin", "zoo", "Zoo"];
 //all of the Biafra/Nigeria/Dance references are because "python" is a symbol in some political current events going on there
 
 

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -73,7 +73,7 @@ function retweet_Python() {
       
       var tweets = twit.fetchTweets(
         TWITTER_SEARCH_PHRASE, function(tweet){
-          isTweetRelevant(tweet);
+         return isTweetRelevant(tweet);
         }, {
           multi: true,
           lang: "en", // Process only English tweets

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -72,7 +72,9 @@ function retweet_Python() {
     if (twit.hasAccess()) {
       
       var tweets = twit.fetchTweets(
-        TWITTER_SEARCH_PHRASE, isTweetRelevant(tweet), {
+        TWITTER_SEARCH_PHRASE, function(tweet){
+          isTweetRelevant(tweet);
+        }, {
           multi: true,
           lang: "en", // Process only English tweets
           count: 5,   // Process 5 tweets in a batch

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -2,11 +2,13 @@ TWITTER_CONSUMER_KEY    = "";
 TWITTER_CONSUMER_SECRET = "";
 TWITTER_ACCESS_TOKEN    = "";
 TWITTER_ACCESS_SECRET   = "";
-TWITTER_SEARCH_PHRASE   = "python";
+TWITTER_SEARCH_PHRASE   = "python -filter:nativeretweets -filter:retweets";
 
 //variables for array of excluded words and a variable for the length of the array
 //words will be added as I continue to find false positives
-var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra", "montypython", "MontyPython", "pet", "Pet", "Dance", "dance", "Police", "police", "Leather", "leather", "Pants", "pants"];
+var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra", 
+                "montypython", "MontyPython", "pet", "Pet", "Dance", "dance", "Police", "police", "Leather", "leather", 
+                "Pants", "pants", "Handbag", "handbag", "forsyth", "Forsyth"];
 var numexcluded = excluded.length;
  
 function Start_Bot() {

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -59,7 +59,7 @@ function retweet_Python() {
     //otherwise it returns the tweet
       function isTweetRelevant(tweetobj){
         for (var i = 0; i < numexcluded; i++){
-          if (tweetobj.text.indexOf(excluded[i]) !== -1 || tweet.possibly_sensitive){
+          if (tweetobj.text.indexOf(excluded[i]) !== -1 || tweetobj.possibly_sensitive){
             return false;
           }
           else {

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -3,11 +3,11 @@ TWITTER_CONSUMER_SECRET = "";
 TWITTER_ACCESS_TOKEN    = "";
 TWITTER_ACCESS_SECRET   = "";
 TWITTER_SEARCH_PHRASE   = "python";
-TWITTER_SEARCH_PHRASE_2 = "Monty";
-TWITTER_SEARCH_PHRASE_3 = "lurking";
 
-
-
+//variables for array of excluded words and a variable for the length of the array
+//array can be modified to contain as many excluded words or phrases as needed
+var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake"];
+var numexcluded = excluded.length;
  
 function Start_Bot() {
   
@@ -53,14 +53,30 @@ function retweet_Python() {
     var props = PropertiesService.getScriptProperties(),
         twit = new Twitter.OAuth(props);
     
+    //function to loop through array of excluded words
+    //created to reduce the number of conditions in the tweet_processor if statement
+    //returns true if tweet contains excluded phrase, otherwise returns false
+    //uses indexOf() instead of includes() since includes() does not work in Google App Scripts
+    function containsExcludedPhrase(tweetobj){
+      for (var i = 0; i < numexcluded; i++){
+        if (tweetobj.text.indexOf(excluded[i]) !== -1){
+          return true;
+        }
+        else {
+          return false;
+        }
+      }
+    }
+    
     if (twit.hasAccess()) {
       
       var tweets = twit.fetchTweets(
         TWITTER_SEARCH_PHRASE, function(tweet) {
-          // Skip tweets that contain sensitive content
-          if (!tweet.possibly_sensitive && !tweet.includes(TWITTER_SEARCH_PHRASE_2) && !tweet.includes(TWITTER_SEARCH_PHRASE_3)) {
+          //skip over possibly sensitive tweets and tweets that contain any of the excluded phrases
+          if (!tweet.possibly_sensitive && !containsExcludedPhrase(tweet)){
             return tweet.id_str;
           }
+          
         }, {
           multi: true,
           lang: "en", // Process only English tweets

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -6,7 +6,7 @@ TWITTER_SEARCH_PHRASE   = "python";
 
 //variables for array of excluded words and a variable for the length of the array
 //words will be added as I continue to find false positives
-var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra", "montypython", "MontyPython", "pet", "Pet", "Dance", "dance"];
+var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra", "montypython", "MontyPython", "pet", "Pet", "Dance", "dance", "Police", "police"];
 var numexcluded = excluded.length;
  
 function Start_Bot() {

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -6,7 +6,7 @@ TWITTER_SEARCH_PHRASE   = "python";
 
 //variables for array of excluded words and a variable for the length of the array
 //words will be added as I continue to find false positives
-var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra"];
+var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra", "montypython", "MontyPython", "pet", "Pet"];
 var numexcluded = excluded.length;
  
 function Start_Bot() {

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -58,14 +58,16 @@ function retweet_Python() {
     //if any of the if conditions match, it returns false (not relevant) and fetchTweets will not fetch it
     //otherwise it returns the tweet
       function isTweetRelevant(tweetobj){
+        
         for (var i = 0; i < numexcluded; i++){
           if (tweetobj.text.indexOf(excluded[i]) !== -1 || tweetobj.possibly_sensitive){
+            Logger.log(tweetobj.text);
             return false;
           }
-          else {
-            return true;
-          }
         }
+        
+        //return true only if return false hasn't triggered from the loop
+        return true;
 
     }
     
@@ -73,7 +75,7 @@ function retweet_Python() {
       
       var tweets = twit.fetchTweets(
         TWITTER_SEARCH_PHRASE, function(tweet){
-         return isTweetRelevant(tweet);
+          return isTweetRelevant(tweet);
         }, {
           multi: true,
           lang: "en", // Process only English tweets

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -6,7 +6,7 @@ TWITTER_SEARCH_PHRASE   = "python";
 
 //variables for array of excluded words and a variable for the length of the array
 //words will be added as I continue to find false positives
-var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra", "montypython", "MontyPython", "pet", "Pet", "Dance", "dance", "Police", "police"];
+var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra", "montypython", "MontyPython", "pet", "Pet", "Dance", "dance", "Police", "police", "Leather", "leather"];
 var numexcluded = excluded.length;
  
 function Start_Bot() {

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -68,10 +68,12 @@ function retweet_Python() {
         if(tweetobj.text.indexOf("python") == -1 && tweetobj.text.indexOf("Python") == -1){
           return false;
         }
+        //make object into a string to search the entire object for unwanted phrases
+        var objstr = JSON.stringify(tweetobj)
         
         //if the tweet is sensitive or contains a non-allowed word, return false
         for (var i = 0; i < numexcluded; i++){
-              if (tweetobj.text.indexOf(excluded[i]) !== -1 || tweetobj.possibly_sensitive){
+              if (objstr.indexOf(excluded[i]) !== -1 || tweetobj.possibly_sensitive){
                 return false;
                 }
               }

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -2,13 +2,16 @@ TWITTER_CONSUMER_KEY    = "";
 TWITTER_CONSUMER_SECRET = "";
 TWITTER_ACCESS_TOKEN    = "";
 TWITTER_ACCESS_SECRET   = "";
-TWITTER_SEARCH_PHRASE   = "python -filter:nativeretweets -filter:retweets";
+TWITTER_SEARCH_PHRASE   = "python -filter:nativeretweets -filter:retweets -filter:replies";
 
 //variables for array of excluded words and a variable for the length of the array
 //words will be added as I continue to find false positives
-var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra", 
-                "montypython", "MontyPython", "pet", "Pet", "Dance", "dance", "Police", "police", "Leather", "leather", 
-                "Pants", "pants", "Handbag", "handbag", "forsyth", "Forsyth"];
+var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra", "BIAFRA", "Biafrans", "biafrans",
+                "montypython", "MontyPython", "pet", "Pet", "Dance", "dance", "Police", "police", "Leather", "leather",
+                "Pants", "pants", "Handbag", "handbag", "forsyth", "Forsyth", "Ball Python" , "Nigeria", "nigeria"];
+//all of the Biafra/Nigeria/Dance references are because "python" is a symbol in some political current events going on there
+
+
 var numexcluded = excluded.length;
  
 function Start_Bot() {
@@ -61,17 +64,25 @@ function retweet_Python() {
     //otherwise it returns the tweet
       function isTweetRelevant(tweetobj){
         
-        for (var i = 0; i < numexcluded; i++){
-          if (tweetobj.text.indexOf(excluded[i]) !== -1 || tweetobj.possibly_sensitive){
-            
-            return false;
-          }
+        //if the tweet text property does not contain the word python in some form, return false
+        //this is a relatively strict rule which may skip semi-relevant tweets. it may filter out some okay results but may be necessary for quality
+        if(tweetobj.text.indexOf("python") == -1 && tweetobj.text.indexOf("Python") == -1){
+          return false;
         }
         
-        //return true only if return false hasn't triggered from the loop
-        return true;
+        //if the tweet is sensitive or contains a non-allowed word, return false
+        for (var i = 0; i < numexcluded; i++){
+              if (tweetobj.text.indexOf(excluded[i]) !== -1 || tweetobj.possibly_sensitive){
+                return false;
+                }
+              }
 
+        
+        //return true only if return false hasn't triggered from the conditions above
+        return true;
       }
+
+   
     
     if (twit.hasAccess()) {
       

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -6,7 +6,7 @@ TWITTER_SEARCH_PHRASE   = "python";
 
 //variables for array of excluded words and a variable for the length of the array
 //words will be added as I continue to find false positives
-var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra", "montypython", "MontyPython", "pet", "Pet"];
+var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra", "montypython", "MontyPython", "pet", "Pet", "Dance", "dance"];
 var numexcluded = excluded.length;
  
 function Start_Bot() {
@@ -53,30 +53,26 @@ function retweet_Python() {
     var props = PropertiesService.getScriptProperties(),
         twit = new Twitter.OAuth(props);
     
-    //function to loop through array of excluded words
-    //created to reduce the number of conditions in the tweet_processor if statement
-    //returns true if tweet contains excluded phrase, otherwise returns false
-    function containsExcludedPhrase(tweetobj){
-      for (var i = 0; i < numexcluded; i++){
-        if (tweetobj.text.indexOf(excluded[i]) !== -1){
-          return true;
+    //reduced function to check if tweet is relevant enough for bot to retweet
+    //filters based on word list and sensitivity
+    //if any of the if conditions match, it returns false (not relevant) and fetchTweets will not fetch it
+    //otherwise it returns the tweet
+      function isTweetRelevant(tweetobj){
+        for (var i = 0; i < numexcluded; i++){
+          if (tweetobj.text.indexOf(excluded[i]) !== -1 || tweet.possibly_sensitive){
+            return false;
+          }
+          else {
+            return true;
+          }
         }
-        else {
-          return false;
-        }
-      }
+
     }
     
     if (twit.hasAccess()) {
       
       var tweets = twit.fetchTweets(
-        TWITTER_SEARCH_PHRASE, function(tweet) {
-          //skip over possibly sensitive tweets and tweets that contain any of the excluded phrases
-          if (!tweet.possibly_sensitive && !containsExcludedPhrase(tweet)){
-            return tweet.id_str;
-          }
-          
-        }, {
+        TWITTER_SEARCH_PHRASE, isTweetRelevant(tweet), {
           multi: true,
           lang: "en", // Process only English tweets
           count: 5,   // Process 5 tweets in a batch

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -6,7 +6,7 @@ TWITTER_SEARCH_PHRASE   = "python";
 
 //variables for array of excluded words and a variable for the length of the array
 //words will be added as I continue to find false positives
-var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra", "montypython", "MontyPython", "pet", "Pet", "Dance", "dance", "Police", "police", "Leather", "leather"];
+var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra", "montypython", "MontyPython", "pet", "Pet", "Dance", "dance", "Police", "police", "Leather", "leather", "Pants", "pants"];
 var numexcluded = excluded.length;
  
 function Start_Bot() {

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -7,8 +7,10 @@ TWITTER_SEARCH_PHRASE   = "python -filter:nativeretweets -filter:retweets -filte
 //variables for array of excluded words and a variable for the length of the array
 //words will be added as I continue to find false positives
 var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra", "BIAFRA", "Biafrans", "biafrans",
-                "montypython", "MontyPython", "pet", "Pet", "Dance", "dance", "Police", "police", "Leather", "leather",
-                "Pants", "pants", "Handbag", "handbag", "forsyth", "Forsyth", "Ball Python" , "Nigeria", "nigeria"];
+                "montypython", "MontyPython", "pet", "Pet", "#pet", "Dance", "dance", "Police", "police", "Leather", "leather",
+                "Pants", "pants", "Handbag", "handbag", "forsyth", "Forsyth", "Ball Python" , "Nigeria", "nigeria", "creatur.io", "Slither.io",
+                "BallPython", "ballpython", "#BallPython", "#ballpython", "Python Temple", "#pythontemple", "Luthier", "versace", "Versace", "Python's Realm",
+                "Dangerous", "jaw", "swallow", "Swallow", "Kyle Python", "Python Plan", "Python Skin", "python skin"];
 //all of the Biafra/Nigeria/Dance references are because "python" is a symbol in some political current events going on there
 
 

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -5,8 +5,8 @@ TWITTER_ACCESS_SECRET   = "";
 TWITTER_SEARCH_PHRASE   = "python";
 
 //variables for array of excluded words and a variable for the length of the array
-//array can be modified to contain as many excluded words or phrases as needed
-var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake"];
+//words will be added as I continue to find false positives
+var excluded = ["Monty", "monty", "lurking", "Lurking", "ball python", "snake", "Snake", "Biafra", "biafra"];
 var numexcluded = excluded.length;
  
 function Start_Bot() {
@@ -56,7 +56,6 @@ function retweet_Python() {
     //function to loop through array of excluded words
     //created to reduce the number of conditions in the tweet_processor if statement
     //returns true if tweet contains excluded phrase, otherwise returns false
-    //uses indexOf() instead of includes() since includes() does not work in Google App Scripts
     function containsExcludedPhrase(tweetobj){
       for (var i = 0; i < numexcluded; i++){
         if (tweetobj.text.indexOf(excluded[i]) !== -1){

--- a/retweet-bot.js
+++ b/retweet-bot.js
@@ -69,7 +69,7 @@ function retweet_Python() {
         //return true only if return false hasn't triggered from the loop
         return true;
 
-    }
+      }
     
     if (twit.hasAccess()) {
       


### PR DESCRIPTION
This PR addresses https://github.com/yogithapolavarapu/Retweet-Bot/issues/1 among with some related issues that surfaced while fixing this one

Changes:
- Many words have been added to the filter, based on problem tweets that I observed my test bot tweeting in the past 2-3 days
- Due to needing a lot of words filtered, I changed the tweet_processor argument to call an isTweetRelevant function (which can be easily changed/adapted by the bot owner to further filter/restrict tweets). 
- Fixed an issue with the SINCE_TWITTER_ID that was throwing errors and preventing some retweets completely that were actually relevant
- Adjusted the query "python" to also filter out retweets, old-style retweets, and replies using twitter's built-in query operators as these had a high probability of being irrelevant or low-quality tweets
- Added a condition to require the tweet text to contain the word Python or python. Initially I thought this would be too strict, but the tweet quality went up after adding it

Some things will still get through, but now adding conditions or words is easy to continue to adapt the filter. 